### PR TITLE
Add gitattributes to block binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Enforce text normalization and help keep binary assets out of the repository
+* text=auto
+
+# Common binary formats marked explicitly
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.bmp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.7z binary
+*.exe binary
+*.dll binary


### PR DESCRIPTION
## Summary
- add a .gitattributes file to normalize text files
- mark common binary formats as binary to help keep them out of the repository

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4c34596c832ca93b94058b911c18)